### PR TITLE
Fix for CVE-2023-24442

### DIFF
--- a/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/Configuration.java
+++ b/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/Configuration.java
@@ -97,14 +97,14 @@ public class Configuration extends AbstractDescribableImpl<Configuration> {
 
         private boolean disableSimpleCov;
         private String gitHubApiUrl;
-        private String personalAccessToken;
+        private Secret  personalAccessToken;
         private String jenkinsUrl;
         private boolean privateJenkinsPublicGitHub;
         private boolean useSonarForMasterCoverage;
         private String sonarUrl;
-        private String sonarToken;
+        private Secret  sonarToken;
         private String sonarLogin;
-        private String sonarPassword;
+        private Secret  sonarPassword;
 
         private int yellowThreshold = DEFAULT_YELLOW_THRESHOLD;
         private int greenThreshold = DEFAULT_GREEN_THRESHOLD;
@@ -135,7 +135,7 @@ public class Configuration extends AbstractDescribableImpl<Configuration> {
 
         @Override
         public String getPersonalAccessToken() {
-            return personalAccessToken;
+            return personalAccessToken  == null ? null : personalAccessToken.getPlainText();
         }
 
         @Override
@@ -170,7 +170,7 @@ public class Configuration extends AbstractDescribableImpl<Configuration> {
 
         @Override
         public String getSonarToken() {
-            return sonarToken;
+            return sonarToken == null ? null : sonarToken.getPlainText();
         }
 
         @Override
@@ -183,14 +183,13 @@ public class Configuration extends AbstractDescribableImpl<Configuration> {
         }
 
         public String getSonarPassword() {
-            return sonarPassword;
+            return sonarPassword == null ? null : sonarPassword.getPlainText();
         }
 
         @Override
         public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
             gitHubApiUrl = StringUtils.trimToNull(formData.getString("gitHubApiUrl"));
-            personalAccessToken = Secret.toString(Secret.fromString(
-                    StringUtils.trimToNull(formData.getString("personalAccessToken"))));
+            personalAccessToken = Secret.fromString(StringUtils.trimToNull(formData.getString("personalAccessToken")));
             yellowThreshold = NumberUtils.toInt(formData.getString("yellowThreshold"), DEFAULT_YELLOW_THRESHOLD);
             greenThreshold = NumberUtils.toInt(formData.getString("greenThreshold"), DEFAULT_GREEN_THRESHOLD);
             jenkinsUrl = StringUtils.trimToNull(formData.getString("jenkinsUrl"));
@@ -198,15 +197,33 @@ public class Configuration extends AbstractDescribableImpl<Configuration> {
             useSonarForMasterCoverage = BooleanUtils.toBoolean(formData.getString("useSonarForMasterCoverage"));
             disableSimpleCov = BooleanUtils.toBoolean(formData.getString("disableSimpleCov"));
             sonarUrl = StringUtils.trimToNull(formData.getString("sonarUrl"));
-            sonarToken = Secret.toString(Secret.fromString(
-                    StringUtils.trimToNull(formData.getString("sonarToken"))));
+            sonarToken = Secret.fromString(StringUtils.trimToNull(formData.getString("sonarToken")));
             sonarLogin = StringUtils.trimToNull(formData.getString("sonarLogin"));
-            sonarPassword = Secret.toString(Secret.fromString(
-                    StringUtils.trimToNull(formData.getString("sonarPassword"))));
+            sonarPassword = Secret.fromString(StringUtils.trimToNull(formData.getString("sonarPassword")));
             save();
             return super.configure(req, formData);
         }
 
+        @Override
+        public void load() {
+            super.load();
+            // Re-wrap secret fields using Secret.fromString to ensure encrypted data storage
+            if (personalAccessToken != null) {
+                personalAccessToken = Secret.fromString(personalAccessToken.getPlainText());
+            }
+            if (sonarToken != null) {
+                sonarToken = Secret.fromString(sonarToken.getPlainText());
+            }
+            if (sonarPassword != null) {
+                sonarPassword = Secret.fromString(sonarPassword.getPlainText());
+            }
+        }
+
+        @Override
+        public void save() {
+            // Additional processing for secret objects can be applied here if needed
+            super.save();
+        }
     }
 
 }

--- a/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/ConfigurationTest.java
+++ b/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/ConfigurationTest.java
@@ -1,0 +1,60 @@
+package com.github.terma.jenkins.githubprcoveragestatus;
+
+import com.github.terma.jenkins.githubprcoveragestatus.Configuration;
+import com.github.terma.jenkins.githubprcoveragestatus.Configuration.ConfigurationDescriptor;
+import hudson.util.Secret;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.junit.Assert.*;
+
+public class ConfigurationTest {
+
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
+
+    @Test
+    public void secretsStoredAsSecretAndExposedAsPlainViaGetter() throws Exception {
+        String ghToken = "ghp_testsecret";
+        String sonarToken = "sonar_token_secret";
+        String sonarPassword = "sonar_pwd_secret";
+
+        ConfigurationDescriptor config = new ConfigurationDescriptor();
+
+        // Set fields via reflection, as Jenkins global config binds via data-binding, not public API
+        setSecretField(config, "personalAccessToken", ghToken);
+        setSecretField(config, "sonarToken", sonarToken);
+        setSecretField(config, "sonarPassword", sonarPassword);
+
+        assertEquals(ghToken, config.getPersonalAccessToken());
+        assertEquals(sonarToken, config.getSonarToken());
+        assertEquals(sonarPassword, config.getSonarPassword());
+
+        Secret ghTokenSecret = getSecretField(config, "personalAccessToken");
+        Secret sonarTokenSecret = getSecretField(config, "sonarToken");
+        Secret sonarPwdSecret = getSecretField(config, "sonarPassword");
+
+        assertNotNull(ghTokenSecret);
+        assertNotEquals(ghToken, ghTokenSecret.getEncryptedValue());
+
+        assertNotNull(sonarTokenSecret);
+        assertNotEquals(sonarToken, sonarTokenSecret.getEncryptedValue());
+
+        assertNotNull(sonarPwdSecret);
+        assertNotEquals(sonarPassword, sonarPwdSecret.getEncryptedValue());
+    }
+
+    private void setSecretField(Object obj, String fieldName, String value) throws Exception {
+        java.lang.reflect.Field f = obj.getClass().getDeclaredField(fieldName);
+        f.setAccessible(true);
+        f.set(obj, Secret.fromString(value));
+    }
+
+    private Secret getSecretField(Object obj, String fieldName) throws Exception {
+        java.lang.reflect.Field f = obj.getClass().getDeclaredField(fieldName);
+        f.setAccessible(true);
+        Object val = f.get(obj);
+        return val instanceof Secret ? (Secret) val : null;
+    }
+}


### PR DESCRIPTION
This PR mitigates [CVE-2023-24442](https://nvd.nist.gov/vuln/detail/CVE-2023-24442), which exposes plaintext secrets (GitHub token, Sonar token, and Sonar password) in the plugin’s configuration XML file (Configuration.xml). All configured secrets were previously stored unencrypted in the Jenkins home directory, posing a serious security risk.